### PR TITLE
Fix name of lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   lint:
-    name: Regression test
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source


### PR DESCRIPTION
Due to a copy paste error, the wrong name was being given to the linting workflow