### PR TITLE
gh-5: Add workflow to run all benchmarks against glass-dev/glass@main

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,16 +25,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          cache-dependency-path: pyproject.toml
           cache: pip
           python-version: "3.13"
 
       - name: Cache nox
         uses: actions/cache@v4
         with:
-          key:
-            tests-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('noxfile.py')
-            }}-${{ env.pythonLocation }}
+          key: tests-${{ hashFiles('noxfile.py') }}-${{ env.pythonLocation }}
           path: .nox
 
       - name: Install nox

--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -38,22 +38,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          cache-dependency-path: pyproject.toml
           cache: pip
           python-version: ${{ matrix.python-version }}
 
       - name: Cache nox
         uses: actions/cache@v4
         with:
-          key:
-            tests-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('noxfile.py')
-            }}-${{ env.pythonLocation }}
+          key: tests-${{ hashFiles('noxfile.py') }}-${{ env.pythonLocation }}
           path: .nox
 
       - name: Install nox
         run: python -m pip install nox
 
       - name: Run regression test
-        run: |
-          nox -s regression_tests-${{ matrix.python-version }} -- \
-            ${{ inputs.starting_revision }} ${{ inputs.end_revision }}
+        run: >-
+          nox -s regression_tests-${{ matrix.python-version }} --
+          ${{ inputs.starting_revision }} ${{ inputs.end_revision }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,21 +32,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          cache-dependency-path: pyproject.toml
           cache: pip
           python-version: ${{ matrix.python-version }}
 
       - name: Cache nox
         uses: actions/cache@v4
         with:
-          key:
-            tests-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('noxfile.py')
-            }}-${{ env.pythonLocation }}
+          key: tests-${{ hashFiles('noxfile.py') }}-${{ env.pythonLocation }}
           path: .nox
 
       - name: Install nox
         run: python -m pip install nox
 
       - name: Run regression test
-        run: |
-          nox -s benchmark-${{ matrix.python-version }} -- main
+        run: nox -s benchmark-${{ matrix.python-version }} -- main


### PR DESCRIPTION
Adds a workflow that will run on pushes to main and pull requests which runs all tests (benchmarks) written in this repo so fair against the main branch of `glass-dev/glass`

closes #5 