### PR TITLE
Explicitly specify benchmarks repo for checkout

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          repository: glass-dev/glass-benchmarks
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
To ensure we use the benchmarks repo when triggering this workflow from glass-dev/glass, we specify the benchmarks repo when checking out the repo.