### PR TITLE
gh-758: Adds benchmarks for functions in algorithm.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import jax.numpy
-import numpy as np
+import numpy  # noqa: ICN001
 import pytest
 
 import array_api_strict
@@ -23,7 +23,7 @@ logging.getLogger("jax").setLevel(logging.ERROR)
 
 xp_available_backends: dict[str, ModuleType] = {
     "array_api_strict": array_api_strict,
-    "numpy": np,
+    "numpy": numpy,
     "jax.numpy": jax.numpy,
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,15 +9,12 @@ import pytest
 
 import array_api_strict
 
-import glass.jax
+import glass._array_api_utils
 
 if TYPE_CHECKING:
     from types import ModuleType
-    from typing import TypeAlias
 
-    UnifiedGenerator: TypeAlias = (
-        np.random.Generator | glass.jax.Generator | glass._array_api_utils.Generator  # noqa: SLF001
-    )
+    from glass._types import UnifiedGenerator
 
 
 # Change jax logger to only log ERROR or worse
@@ -50,13 +47,4 @@ def urng(xp: ModuleType) -> UnifiedGenerator:
 
     Must be used with the `xp` fixture. Use `rng` for non array API tests.
     """
-    seed = 42
-    backend = xp.__name__
-    if backend == "jax.numpy":
-        return glass.jax.Generator(seed=seed)
-    if backend == "numpy":
-        return np.random.default_rng(seed=seed)
-    if backend == "array_api_strict":
-        return glass._array_api_utils.Generator(seed=seed)  # noqa: SLF001
-    msg = "the array backend in not supported"
-    raise NotImplementedError(msg)
+    return glass._array_api_utils.rng_dispatcher(xp=xp)  # noqa: SLF001

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,32 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import jax.numpy
-import numpy  # noqa: ICN001
+import numpy as np
 import pytest
 
 import array_api_strict
 
+import glass.jax
+
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import TypeAlias
+
+    UnifiedGenerator: TypeAlias = (
+        np.random.Generator | glass.jax.Generator | glass._array_api_utils.Generator  # noqa: SLF001
+    )
+
+
+# Change jax logger to only log ERROR or worse
+logging.getLogger("jax").setLevel(logging.ERROR)
+
 
 xp_available_backends: dict[str, ModuleType] = {
     "array_api_strict": array_api_strict,
-    "numpy": numpy,
+    "numpy": np,
     "jax.numpy": jax.numpy,
 }
 
@@ -26,3 +39,24 @@ def xp(request: pytest.FixtureRequest) -> ModuleType:
     Access array library functions using `xp.` in tests.
     """
     return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture(scope="session")
+def urng(xp: ModuleType) -> UnifiedGenerator:
+    """
+    Fixture for a unified RNG interface.
+
+    Access the relevant RNG using `urng.` in tests.
+
+    Must be used with the `xp` fixture. Use `rng` for non array API tests.
+    """
+    seed = 42
+    backend = xp.__name__
+    if backend == "jax.numpy":
+        return glass.jax.Generator(seed=seed)
+    if backend == "numpy":
+        return np.random.default_rng(seed=seed)
+    if backend == "array_api_strict":
+        return glass._array_api_utils.Generator(seed=seed)  # noqa: SLF001
+    msg = "the array backend in not supported"
+    raise NotImplementedError(msg)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -63,3 +63,34 @@ def test_cov_clip(
     if rtol is not None:
         h = xp.max(xp.linalg.eigvalsh(a))
         np.testing.assert_allclose(xp.linalg.eigvalsh(cov), h, rtol=1e-6)
+
+
+@pytest.mark.parametrize("tol", [None, 0.0001])
+def test_nearcorr(
+    xp: ModuleType,
+    benchmark: BenchmarkFixture,
+    tol: float | None,
+) -> None:
+    """
+    Benchmark test for glass.algorithm.nearcorr.
+
+    Parameterize over tol to ensure the most coverage possible.
+    """
+    # from Higham (2002)
+    a = xp.asarray(
+        [
+            [1.0, 1.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ],
+    )
+    b = xp.asarray(
+        [
+            [1.0000, 0.7607, 0.1573],
+            [0.7607, 1.0000, 0.7607],
+            [0.1573, 0.7607, 1.0000],
+        ],
+    )
+
+    x = benchmark(glass.algorithm.nearcorr, a, tol=tol)
+    np.testing.assert_allclose(x, b, atol=0.0001)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -94,3 +94,22 @@ def test_nearcorr(
 
     x = benchmark(glass.algorithm.nearcorr, a, tol=tol)
     np.testing.assert_allclose(x, b, atol=0.0001)
+
+
+def test_cov_nearest(
+    xp: ModuleType,
+    urng: UnifiedGenerator,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark test for glass.algorithm.cov_nearest."""
+    # prepare a random matrix
+    m = urng.random((4, 4))
+
+    # symmetric matrix
+    a = xp.eye(4) + (m + m.T) / 2
+
+    # compute covariance
+    cov = benchmark(glass.algorithm.cov_nearest, a)
+
+    # make sure all eigenvalues are positive
+    assert xp.all(xp.linalg.eigvalsh(cov) >= 0)


### PR DESCRIPTION
Adding benchmarks for `glass.algorithm` functions. Mostly these benchmarks are copies of the tests that exist in glass already. However, I have removed sad paths tests which exit early as I believe these are not as relevant for testing the performance of these functions in a working state.

There is still work to be done for benchmarking `glass.algorithm.nnls` as this is not fully covered. Should be handled in https://github.com/glass-dev/glass/issues/759

Should probably wait for #14.