### PR TITLE
gh-22: Upload artifact with output of regression test

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -74,23 +74,8 @@ jobs:
           ${{ inputs.starting_revision }} ${{ inputs.end_revision }}
             | tee $REGRESSION_TEST_OUTPUT_FILE
 
-      - name: Extract regression information for PR comment
-        id: extract_comment
-        if: failure()
-        run: >-
-          f=$REGRESSION_TEST_OUTPUT_FILE
-
-          start=$(grep -n -m1 'Performance has regressed:' "$f" | cut -d: -f1)
-            || { echo "No match"; exit 1; }
-          s_dash=$(awk -v n=$start 'NR<=n && /^-+$/ {l=NR} END{print l}' "$f")
-          e_dash=$(awk -v n=$start 'NR>=n && /^-+$/ {print NR; exit}' "$f")
-          PR_COMMENT_MSG=$(sed -n "${s_dash},${e_dash}p" "$f")
-
-          echo "PR_COMMENT_MSG=$PR_COMMENT_MSG" >> $GITHUB_OUTPUT
-
-      - name: Write PR comment
-        uses: mshick/add-pr-comment@v2
-        if: failure()
+      - name: Upload artefact
+        uses: actions/upload-artifact@v5
         with:
-          message: >-
-            ${{ steps.extract_comment.outputs.PR_COMMENT_MSG }}
+          name: regression_output
+          path: $REGRESSION_TEST_OUTPUT_FILE

--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -32,6 +32,9 @@ on:
         required: true
         type: string
 
+env:
+  REGRESSION_TEST_OUTPUT_FILE: output.txt
+
 jobs:
   regression-test:
     name: Regression test
@@ -69,3 +72,25 @@ jobs:
         run: >-
           nox -s regression_tests-${{ matrix.python-version }} --
           ${{ inputs.starting_revision }} ${{ inputs.end_revision }}
+            | tee $REGRESSION_TEST_OUTPUT_FILE
+
+      - name: Extract regression information for PR comment
+        id: extract_comment
+        if: failure()
+        run: >-
+          f=$REGRESSION_TEST_OUTPUT_FILE
+
+          start=$(grep -n -m1 'Performance has regressed:' "$f" | cut -d: -f1)
+            || { echo "No match"; exit 1; }
+          s_dash=$(awk -v n=$start 'NR<=n && /^-+$/ {l=NR} END{print l}' "$f")
+          e_dash=$(awk -v n=$start 'NR>=n && /^-+$/ {print NR; exit}' "$f")
+          PR_COMMENT_MSG=$(sed -n "${s_dash},${e_dash}p" "$f")
+
+          echo "PR_COMMENT_MSG=$PR_COMMENT_MSG" >> $GITHUB_OUTPUT
+
+      - name: Write PR comment
+        uses: mshick/add-pr-comment@v2
+        if: failure()
+        with:
+          message: >-
+            ${{ steps.extract_comment.outputs.PR_COMMENT_MSG }}


### PR DESCRIPTION
Adds steps to upload an artifact containing the output of the regression test. This can then be downloaded by the calling workflow to be used to add a comment to the PR